### PR TITLE
Exits project creation if name is empty or invalid

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -16,6 +16,7 @@ import {
   promptProjectStack,
 } from "./src/utils/prompts.js";
 import { createFrontendProject } from "./src/utils/create-frontend-project.js";
+import { exit } from "shelljs";
 
 const toolName = "StartEase";
 const jsBackendStacks = ["expressjs", "nestjs"];
@@ -48,6 +49,15 @@ async function startProject() {
   console.log(chalk.white(initialMsg));
 
   projectName = await promptProjectName();
+  if (projectName === "") {
+    console.log(`Project name can't be empty.`);
+    exit()
+  }
+  if (!/^[a-z0-9-._~]+$/.test(projectName)) {
+    console.log(`Project name can only contain lowercase letters, numbers, "-", ".", "_" and "~".`);
+    exit();
+  }
+  
   projectStack = await promptProjectStack();
 
   /**


### PR DESCRIPTION
I've made it so that the creation process stops if the project name entered either is empty or contains any characters other than lowercase letters, numbers or URI-safe special charaters.

Issue #42 